### PR TITLE
Changed "Apply for a grant" to "Grants program"

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -54,7 +54,7 @@ import joinPreviewUrl from "../images/join-preview.png";
 
 <Layout>
 	<PairedBlock
-		left={<PagePreview title={"Apply for a&nbsp;grant"} actionTitle={"Learn more"} imageSrc={grantPreviewUrl} url={"grants"} />}
+		left={<PagePreview title={"Grants&nbsp;program"} actionTitle={"Learn more"} imageSrc={grantPreviewUrl} url={"grants"} />}
 		right={<PagePreview title={"Join the Foundation"} actionTitle={"Continue"} imageSrc={joinPreviewUrl} url={"join"} />}
 	/>
 </Layout>


### PR DESCRIPTION
Submissions are closed so it makes sense to rename the block.