### PR TITLE
KTL-1150, KTL-1161: layout fixes

### DIFF
--- a/src/components/LatestNews/index.tsx
+++ b/src/components/LatestNews/index.tsx
@@ -94,7 +94,7 @@ function NewsPreview({ className = '', post, spoilerSize, ...props }: NewsPrevie
         post.excerpt,
         spoilerSize || postSpoilerSize,
         <Link href={post.fields.slug} className={classes}>
-          Read more
+          Read&nbsp;more
         </Link>
       ),
     [post, spoilerSize]

--- a/src/components/Post/Post.module.css
+++ b/src/components/Post/Post.module.css
@@ -1,7 +1,3 @@
-.date {
-  margin-top: var(--ktf-fuild-spacing-xl);
-}
-
 .title {
   margin-top: calc(var(--ktl-box-section-s) / 2);
   margin-bottom: var(--ktl-box-section-l);

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -64,7 +64,7 @@ export default function PageTemplate({ children, ...props }: PageTemplateProps) 
 
   return (
     <Layout {...props} socialImage={coverImage}>
-      <p className={cn(textCn('ktl-text-3'), 'ktl-text--gray', style.date)}>{date}</p>
+      <p className={cn(textCn('ktl-text-3'), 'ktl-text--gray')}>{date}</p>
       <h1 className={cn('ktf-h2 ktf-h3--mm', style.title)}>{title}</h1>
       <Markdown>{children}</Markdown>
     </Layout>

--- a/src/components/Posts/posts.module.css
+++ b/src/components/Posts/posts.module.css
@@ -67,6 +67,7 @@
 .imageTag {
   max-width: 328px;
   width: 100%;
+  border-radius: 16px;
 
   @media (--ktl-ms) {
     max-width: 272px;


### PR DESCRIPTION
- [x] Latest news cover images should have rounded conners
- [x] "Read more" in Latest news preview cards should have unbreakable space
- [x] Margin top at the news page should be 72px

PS the requirement for the news cards to have the same number of description lines looks already implementet