### PR TITLE
Add KotlinConf 2024 Keynote

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -73,27 +73,31 @@ import joinPreviewUrl from "../images/join-preview.png";
 <VideoGallery videos={
   [
     {
+      title: 'KotlinConf 2024 Keynote',
+      url: 'https://www.youtube.com/watch?v=Ar73Axsz2YA'
+    },
+    {
       title: 'Kotlin Anniversary Documentary',
       url: 'https://www.youtube.com/watch?v=uE-1oF9PyiY'
     },
     {
-      title: 'Kotlin 2023 Keynote',
+      title: 'KotlinConf 2023 Keynote',
       url: 'https://www.youtube.com/watch?v=c4f4SCEYA5Q'
     },
     {
-      title: 'Kotlin 2021 Keynote',
+      title: 'KotlinConf 2021 Keynote',
       url: 'https://www.youtube.com/watch?v=3uVUDsoE_5U'
     },
     {
-      title: 'Kotlin 2020 Keynote',
+      title: 'KotlinConf 2020 Keynote',
       url: 'https://www.youtube.com/watch?v=pD58Dw17CLk'
     },
     {
-      title: 'Kotlin 2019 Keynote',
+      title: 'KotlinConf 2019 Keynote',
       url: 'https://www.youtube.com/watch?v=0xKTM0A8gdI'
     },
     {
-      title: 'Kotlin 2018 Keynote',
+      title: 'KotlinConf 2018 Keynote',
       url: 'https://www.youtube.com/watch?v=PsaFVLr8t4E&list=PLQ176FUIyIUbVvFMqDc2jhxS-t562uytr&index=2'
     }
   ]


### PR DESCRIPTION
I've added a KotlinConf 2024 Keynote on the home page and updated titles of other keynotes to say KotlinConf, not Kotlin.